### PR TITLE
`@evaluate` pytest decorator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,4 +29,8 @@ unittests:
 	uv run coverage run -m pytest --durations=0 tests
 	uv run coverage html
 
-tests: linting unittests
+decorator-examples:
+	# Run pytest decorator examples to validate functionality
+	uv run pytest examples/pytest_decorator_example.py --timeout=30
+
+tests: linting unittests decorator-examples

--- a/README.md
+++ b/README.md
@@ -39,7 +39,31 @@ print(f"Evaluation completed: {results.status}")
 print(f"Passed: {results.results[0].check_results[0].results}")
 ```
 
+## Pytest Integration
+
+Use the `@evaluate` decorator to test functions with automatic evaluation:
+
+```python
+from flex_evals import TestCase, Check, CheckType
+from flex_evals.pytest_decorator import evaluate
+
+@evaluate(
+    test_cases=[TestCase(input="What is Python?")],
+    checks=[
+        Check(
+            type=CheckType.CONTAINS,
+            arguments={"text": "$.output.value", "phrases": ["Python", "programming"]},
+        ),
+    ],
+    samples=10,
+    success_threshold=0.8,  # Expect 80% success
+)
+def test_python_explanation(test_case: TestCase) -> str:
+    return my_llm(test_case.input)  # Call your LLM or system here
+```
+
 **See `examples` directory for more detailed usage examples**:
+- **[Pytest Decorator Examples](examples/pytest_decorator_example.py)** - Complete pytest integration examples
 - **[Quickstart Notebook](examples/quickstart.ipynb)** - Introduction to FEP concepts
 - **[Advanced Examples](examples/example_yaml_test_cases.ipynb)** - Using YAML for defining test cases
 - **[LLM-as-a-Judge](examples/llm-as-a-judge.ipynb)** - Using YAML for defining test cases

--- a/examples/pytest_decorator_example.py
+++ b/examples/pytest_decorator_example.py
@@ -44,9 +44,12 @@ def simple_quality_judge(prompt: str, response_format: type) -> tuple:
     samples=3,
     success_threshold=1.0,  # Expect 100% success
 )
-def test_python_explanation() -> str:
+def test_python_explanation(test_case: TestCase) -> str:
     """Deterministic function that always produces good Python explanations."""
-    return "Python is a popular programming language known for simplicity."
+    # Use test_case.input to generate more contextual response
+    if "Python" in test_case.input:
+        return "Python is a popular programming language known for simplicity."
+    return "Python is a versatile programming language."
 
 
 # Example 2: Multiple check types
@@ -69,10 +72,17 @@ def test_python_explanation() -> str:
     samples=2,
     success_threshold=1.0,
 )
-def test_code_generation() -> dict:
+def test_code_generation(test_case: TestCase) -> dict:
     """Generate code examples with multiple validation checks."""
+    # Use test_case.input to generate contextual code
+    if "example" in test_case.input:
+        return {
+            "code": "print('Hello, World!')",
+            "type": "example",
+            "language": "python",
+        }
     return {
-        "code": "print('Hello, World!')",
+        "code": "print('Generated code')",
         "type": "example",
         "language": "python",
     }
@@ -94,9 +104,10 @@ test_case_with_checks = TestCase(
     samples=2,
     success_threshold=1.0,
 )
-def test_with_testcase_checks() -> str:
+def test_with_testcase_checks(test_case: TestCase) -> str:
     """Demonstrate TestCase-defined checks pattern."""
-    return "Operation completed successfully"
+    # Use test_case.input for more dynamic response
+    return f"Operation for '{test_case.input}' completed successfully"
 
 
 # Example 4: LLM Judge integration
@@ -113,10 +124,18 @@ def test_with_testcase_checks() -> str:
     samples=2,
     success_threshold=1.0,
 )
-def test_llm_quality_assessment() -> str:
+def test_llm_quality_assessment(test_case: TestCase) -> str:
     """Demonstrate LLM judge evaluation with deterministic mock."""
-    # Long response with "Python" keyword will pass the mock judge
-    return "Python is an excellent programming language for beginners and experts alike, offering clear syntax and powerful libraries."  # noqa: E501
+    # Use test_case.input to generate contextual response
+    if "AI" in test_case.input:
+        return (
+            "Python is an excellent programming language for AI development, "
+            "offering clear syntax and powerful libraries like TensorFlow and PyTorch."
+        )
+    return (
+        "Python is an excellent programming language for beginners and experts alike, "
+        "offering clear syntax and powerful libraries."
+    )
 
 
 # Example 5: Statistical threshold demonstration
@@ -129,7 +148,7 @@ def test_llm_quality_assessment() -> str:
     samples=4,
     success_threshold=0.75,  # 75% threshold (3 out of 4 must pass)
 )
-def test_statistical_threshold() -> str:
+def test_statistical_threshold(test_case: TestCase) -> str:  # noqa: ARG001
     """Demonstrate statistical threshold with predictable variance."""
     # Simple counter-based approach for deterministic behavior
     if hasattr(test_statistical_threshold, '_counter'):
@@ -154,18 +173,18 @@ def test_statistical_threshold() -> str:
     samples=4,  # Will cycle: math, string, math, string
     success_threshold=1.0,
 )
-def test_cycling_test_cases() -> str:
+def test_cycling_test_cases(test_case: TestCase) -> str:
     """Demonstrate cycling through multiple test cases."""
-    # Counter for deterministic cycling behavior
-    if hasattr(test_cycling_test_cases, '_counter'):
-        test_cycling_test_cases._counter += 1
-    else:
-        test_cycling_test_cases._counter = 1
-
-    # Return appropriate response based on test case cycling
-    if test_cycling_test_cases._counter % 2 == 1:
-        return "4"  # For math test case (2+2 = 4)
-    return "HELLO"  # For string test case (hello -> HELLO)
+    # Use test_case to determine appropriate response
+    if test_case.id == "math":
+        # For math test case: evaluate the input expression
+        if test_case.input == "2+2":
+            return "4"
+        return str(eval(test_case.input))  # Simple evaluation for demo
+    if test_case.id == "string":
+        # For string test case: uppercase the input
+        return test_case.input.upper()
+    return test_case.expected  # Fallback to expected value
 
 
 if __name__ == "__main__":

--- a/examples/pytest_decorator_example.py
+++ b/examples/pytest_decorator_example.py
@@ -1,0 +1,182 @@
+"""
+Simple, deterministic examples of the @evaluate pytest decorator.
+
+This script demonstrates the core @evaluate decorator functionality with predictable,
+deterministic examples that will always pass when run as tests.
+
+To run: pytest examples/pytest_decorator_example.py -v
+"""
+
+from pydantic import BaseModel, Field
+
+from flex_evals.constants import CheckType
+from flex_evals.pytest_decorator import evaluate
+from flex_evals.schemas import TestCase, Check
+
+
+# Simple response format for LLM judge demo
+class QualityResult(BaseModel):
+    """Simple quality assessment result."""
+
+    passed: bool = Field(description="Whether the response passed quality check")
+    score: int = Field(ge=1, le=5, description="Quality score")
+
+
+def simple_quality_judge(prompt: str, response_format: type) -> tuple:
+    """Deterministic mock LLM that evaluates based on content length and keywords."""
+    # Simple rules: good responses are longer and contain "Python"
+    good_response = len(prompt) > 50 and "Python" in prompt
+
+    if good_response:
+        result = response_format(passed=True, score=4)
+    else:
+        result = response_format(passed=False, score=2)
+
+    return result, {"cost": 0.01, "model": "simple-judge"}
+
+
+# Example 1: Basic deterministic success
+@evaluate(
+    test_cases=[TestCase(id="basic", input="What is Python?")],
+    checks=[Check(
+        type=CheckType.CONTAINS,
+        arguments={"text": "$.output.value", "phrases": ["Python", "programming"]},
+    )],
+    samples=3,
+    success_threshold=1.0,  # Expect 100% success
+)
+def test_python_explanation() -> str:
+    """Deterministic function that always produces good Python explanations."""
+    return "Python is a popular programming language known for simplicity."
+
+
+# Example 2: Multiple check types
+@evaluate(
+    test_cases=[TestCase(
+        id="multi_check",
+        input="code example",
+        expected="example",
+    )],
+    checks=[
+        Check(
+            type=CheckType.CONTAINS,
+            arguments={"text": "$.output.value.code", "phrases": ["print"]},
+        ),
+        Check(
+            type=CheckType.EXACT_MATCH,
+            arguments={"expected": "$.test_case.expected", "actual": "$.output.value.type"},
+        ),
+    ],
+    samples=2,
+    success_threshold=1.0,
+)
+def test_code_generation() -> dict:
+    """Generate code examples with multiple validation checks."""
+    return {
+        "code": "print('Hello, World!')",
+        "type": "example",
+        "language": "python",
+    }
+
+
+# Example 3: TestCase-defined checks
+test_case_with_checks = TestCase(
+    id="self_contained",
+    input="demo",
+    checks=[Check(
+        type=CheckType.CONTAINS,
+        arguments={"text": "$.output.value", "phrases": ["success"]},
+    )],
+)
+
+@evaluate(
+    test_cases=[test_case_with_checks],
+    checks=None,  # Use TestCase's own checks
+    samples=2,
+    success_threshold=1.0,
+)
+def test_with_testcase_checks() -> str:
+    """Demonstrate TestCase-defined checks pattern."""
+    return "Operation completed successfully"
+
+
+# Example 4: LLM Judge integration
+@evaluate(
+    test_cases=[TestCase(id="quality", input="AI explanation")],
+    checks=[Check(
+        type=CheckType.LLM_JUDGE,
+        arguments={
+            "prompt": "Evaluate this explanation: {{$.output.value}}",
+            "response_format": QualityResult,
+            "llm_function": simple_quality_judge,
+        },
+    )],
+    samples=2,
+    success_threshold=1.0,
+)
+def test_llm_quality_assessment() -> str:
+    """Demonstrate LLM judge evaluation with deterministic mock."""
+    # Long response with "Python" keyword will pass the mock judge
+    return "Python is an excellent programming language for beginners and experts alike, offering clear syntax and powerful libraries."  # noqa: E501
+
+
+# Example 5: Statistical threshold demonstration
+@evaluate(
+    test_cases=[TestCase(id="variable", input="test")],
+    checks=[Check(
+        type=CheckType.EXACT_MATCH,
+        arguments={"expected": "pass", "actual": "$.output.value"},
+    )],
+    samples=4,
+    success_threshold=0.75,  # 75% threshold (3 out of 4 must pass)
+)
+def test_statistical_threshold() -> str:
+    """Demonstrate statistical threshold with predictable variance."""
+    # Simple counter-based approach for deterministic behavior
+    if hasattr(test_statistical_threshold, '_counter'):
+        test_statistical_threshold._counter += 1
+    else:
+        test_statistical_threshold._counter = 1
+
+    # Return "pass" for first 3 calls, "fail" for 4th call (75% success)
+    return "pass" if test_statistical_threshold._counter <= 3 else "fail"
+
+
+# Example 6: Multiple test cases cycling
+@evaluate(
+    test_cases=[
+        TestCase(id="math", input="2+2", expected="4"),
+        TestCase(id="string", input="hello", expected="HELLO"),
+    ],
+    checks=[Check(
+        type=CheckType.EXACT_MATCH,
+        arguments={"expected": "$.test_case.expected", "actual": "$.output.value"},
+    )],
+    samples=4,  # Will cycle: math, string, math, string
+    success_threshold=1.0,
+)
+def test_cycling_test_cases() -> str:
+    """Demonstrate cycling through multiple test cases."""
+    # Counter for deterministic cycling behavior
+    if hasattr(test_cycling_test_cases, '_counter'):
+        test_cycling_test_cases._counter += 1
+    else:
+        test_cycling_test_cases._counter = 1
+
+    # Return appropriate response based on test case cycling
+    if test_cycling_test_cases._counter % 2 == 1:
+        return "4"  # For math test case (2+2 = 4)
+    return "HELLO"  # For string test case (hello -> HELLO)
+
+
+if __name__ == "__main__":
+    print("Simple @evaluate decorator examples")
+    print("Run with: pytest examples/pytest_decorator_example.py -v")
+    print()
+    print("Examples included:")
+    print("  test_python_explanation: Basic contains check")
+    print("  test_code_generation: Multiple check types")
+    print("  test_with_testcase_checks: TestCase-defined checks")
+    print("  test_llm_quality_assessment: LLM judge integration")
+    print("  test_statistical_threshold: Statistical evaluation")
+    print("  test_cycling_test_cases: Multiple test cases")

--- a/examples/pytest_decorator_example.py
+++ b/examples/pytest_decorator_example.py
@@ -194,7 +194,10 @@ def test_with_simple_fixture(test_case: TestCase, simple_fixture) -> str:  # noq
     test_cases=[TestCase(id="multi_fixture", input="combined")],
     checks=[Check(
         type=CheckType.EXACT_MATCH,
-        arguments={"expected": "fixture_value+user_data_123+combined", "actual": "$.output.value"},
+        arguments={
+            "expected": "fixture_value+user_data_123+combined",
+            "actual": "$.output.value",
+        },
     )],
     samples=2,
     success_threshold=1.0,

--- a/examples/pytest_decorator_example.py
+++ b/examples/pytest_decorator_example.py
@@ -9,9 +9,8 @@ To run: pytest examples/pytest_decorator_example.py -v
 
 from pydantic import BaseModel, Field
 
-from flex_evals.constants import CheckType
+from flex_evals import TestCase, Check, CheckType
 from flex_evals.pytest_decorator import evaluate
-from flex_evals.schemas import TestCase, Check
 
 
 # Simple response format for LLM judge demo

--- a/src/flex_evals/pytest_decorator.py
+++ b/src/flex_evals/pytest_decorator.py
@@ -1,0 +1,332 @@
+"""
+Pytest decorator for statistical evaluation using flex-evals.
+
+This module provides the @evaluate decorator that allows running test functions
+multiple times and validating success rates using existing flex-evals checks.
+"""
+
+import functools
+import traceback
+from typing import Any, TypeVar
+from collections.abc import Callable
+
+import pytest
+
+from .engine import evaluate as engine_evaluate
+from .schemas import TestCase, Output, Check, CheckResult
+
+F = TypeVar('F', bound=Callable[..., Any])
+
+
+def evaluate(
+    test_cases: list[TestCase],
+    checks: list[Check] | None = None,
+    samples: int = 1,
+    success_threshold: float = 1.0,
+) -> Callable[[F], F]:
+    """
+    Pytest decorator for statistical evaluation of test functions.
+
+    This decorator executes the wrapped function multiple times and validates
+    the success rate using existing flex-evals checks. It integrates with
+    pytest's testing framework and provides rich failure reporting.
+
+    EXECUTION FLOW:
+    ==============
+
+    1. Execute the wrapped function `samples` number of times
+    2. Collect all return values and any exceptions
+    3. Reuse original TestCase objects (cycling through if multiple)
+    4. Wrap function outputs in Output objects
+    5. Call engine.evaluate() with test cases, outputs, and checks
+    6. Extract 'passed' field from CheckResult objects
+    7. Calculate success rate and compare against threshold
+    8. Use pytest.fail() with detailed reporting if threshold not met
+
+    CHECK SOURCES:
+    =============
+
+    Checks can be provided in two ways:
+    1. Via the checks parameter (shared across all test cases)
+    2. Via TestCase.checks field (per-test-case checks)
+
+    If checks parameter is provided, it overrides any checks defined in TestCase objects.
+    If checks=None, each TestCase must define its own checks.
+
+    TEST CASE REUSE:
+    ===============
+
+    The decorator reuses the original TestCase objects for each sample:
+    - Preserves original input structure (JSONPath expressions work correctly)
+    - Preserves expected values for comparison checks
+    - Preserves check definitions if using TestCase.checks pattern
+    - No side effects since engine.evaluate() only reads TestCase data
+
+    If the original test_cases list has multiple items, the decorator cycles
+    through them to provide variety in the evaluation.
+
+    OUTPUT WRAPPING:
+    ===============
+
+    Function return values are wrapped in Output objects:
+    - Value: The actual function return value
+    - Simple structure preserving the original data
+
+    For exceptions, error outputs are created with exception details including
+    error type, message, and traceback information.
+
+    SUCCESS RATE CALCULATION:
+    ========================
+
+    The decorator extracts the 'passed' field from each CheckResult:
+    - Counts total samples executed
+    - Counts samples where all checks passed
+    - Calculates success_rate = passed_samples / total_samples
+    - Compares against success_threshold
+
+    PYTEST INTEGRATION:
+    ==================
+
+    - Uses pytest.fail() for threshold failures with detailed message
+    - Provides rich reporting showing:
+      * Total samples executed
+      * Number passed/failed
+      * Success rate achieved vs required
+      * Details of failed samples
+      * Exception details if any occurred
+
+    Args:
+        test_cases: List of TestCase objects to cycle through for evaluation
+        checks: Optional list of checks to apply to all samples
+        samples: Number of times to execute the function (default: 1)
+        success_threshold: Minimum success rate required (0.0 to 1.0, default: 1.0)
+
+    Returns:
+        Decorated function that performs statistical evaluation
+
+    Raises:
+        ValueError: If checks configuration is invalid
+        pytest.fail: If success threshold is not met
+
+    Example:
+        @evaluate(
+            test_cases=[TestCase(id="basic", input="sample input")],
+            checks=[Check(
+                type=CheckType.CONTAINS,
+                arguments={"text": "$.output.value", "phrases": ["expected"]},
+            )],
+            samples=10,
+            success_threshold=0.8
+        )
+        def test_my_function():
+            return {"result": "expected output"}
+
+    Error Handling:
+        - Function exceptions are caught and counted as failures
+        - Invalid check configurations raise ValueError at decoration time
+        - Missing 'passed' field in CheckResult raises clear error
+        - Incompatible checks (no 'passed' field) are validated early
+    """
+    def decorator(func: F) -> F:
+        # Validate decorator parameters
+        if not test_cases:
+            raise ValueError("test_cases list cannot be empty")
+
+        if samples <= 0:
+            raise ValueError("samples must be positive")
+
+        if not 0.0 <= success_threshold <= 1.0:
+            raise ValueError("success_threshold must be between 0.0 and 1.0")
+
+        # Validate check configuration
+        _validate_check_configuration(test_cases, checks)
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs) -> None:  # noqa: ANN002, ANN003
+            # Execute function multiple times and collect results
+            outputs = []
+            test_cases_for_evaluation = []
+            exceptions = []
+
+            for sample_idx in range(samples):
+                try:
+                    # Execute the function
+                    result = func(*args, **kwargs)
+
+                    # Create Output object
+                    output = Output(value=result)
+                    outputs.append(output)
+                    exceptions.append(None)
+
+                except Exception as e:
+                    # Create error output for exception
+                    error_output = Output(
+                        value={
+                            "error": True,
+                            "exception_type": type(e).__name__,
+                            "exception_message": str(e),
+                            "traceback": traceback.format_exc(),
+                        },
+                    )
+                    outputs.append(error_output)
+                    exceptions.append(e)
+
+                # Just reuse the original test case - no copying needed!
+                base_test_case = test_cases[sample_idx % len(test_cases)]
+                test_cases_for_evaluation.append(base_test_case)
+
+            # Evaluate using flex-evals engine
+            try:
+                evaluation_result = engine_evaluate(
+                    test_cases=test_cases_for_evaluation,
+                    outputs=outputs,
+                    checks=checks,
+                )
+            except Exception as e:
+                pytest.fail(f"Evaluation failed: {e}")
+
+            # Extract passed status from check results
+            passed_count = 0
+            failed_samples = []
+
+            for i, test_case_result in enumerate(evaluation_result.results):
+                sample_passed = _check_sample_passed(test_case_result.check_results)
+                if sample_passed:
+                    passed_count += 1
+                else:
+                    failed_samples.append({
+                        "sample_index": i,
+                        "exception": exceptions[i],
+                        "check_results": test_case_result.check_results,
+                    })
+
+            # Calculate success rate
+            success_rate = passed_count / samples
+
+            # Check if threshold is met
+            if success_rate < success_threshold:
+                _generate_failure_report(
+                    func_name=func.__name__,
+                    samples=samples,
+                    passed_count=passed_count,
+                    success_rate=success_rate,
+                    success_threshold=success_threshold,
+                    failed_samples=failed_samples,
+                )
+            # Test passed - return None (pytest convention)
+        return wrapper
+    return decorator
+
+
+def _validate_check_configuration(test_cases: list[TestCase], checks: list[Check] | None) -> None:
+    """
+    Validate that check configuration is valid for evaluation.
+
+    Args:
+        test_cases: List of test cases
+        checks: Optional shared checks
+
+    Raises:
+        ValueError: If configuration is invalid
+    """
+    if checks is None:
+        # Each test case must have checks defined
+        for test_case in test_cases:
+            if not test_case.checks:
+                raise ValueError(
+                    f"When checks=None, each TestCase must define its own checks. "
+                    f"TestCase '{test_case.id}' has no checks defined.",
+                )
+
+
+def _check_sample_passed(check_results: list[CheckResult]) -> bool:
+    """
+    Check if a sample passed by examining all check results.
+
+    A sample passes if all checks have a 'passed' field that is True.
+
+    Args:
+        check_results: List of check results for a sample
+
+    Returns:
+        bool: True if sample passed, False otherwise
+
+    Raises:
+        ValueError: If any check result doesn't have a 'passed' field
+    """
+    if not check_results:
+        return False
+
+    for check_result in check_results:
+        if check_result.status != 'completed':
+            return False
+
+        if 'passed' not in check_result.results:
+            raise ValueError(
+                f"Check result for '{check_result.check_type}' is missing 'passed' field. "
+                f"This check type is not compatible with the @evaluate decorator.",
+            )
+
+        if not check_result.results['passed']:
+            return False
+
+    return True
+
+
+def _generate_failure_report(
+    func_name: str,
+    samples: int,
+    passed_count: int,
+    success_rate: float,
+    success_threshold: float,
+    failed_samples: list[dict],
+) -> None:
+    """
+    Generate detailed failure report and call pytest.fail().
+
+    Args:
+        func_name: Name of the test function
+        samples: Total number of samples
+        passed_count: Number of samples that passed
+        success_rate: Calculated success rate
+        success_threshold: Required success threshold
+        failed_samples: List of failed sample details
+    """
+    failed_count = samples - passed_count
+
+    report_lines = [
+        f"Statistical evaluation failed for {func_name}:",
+        f"  Total samples: {samples}",
+        f"  Passed: {passed_count}",
+        f"  Failed: {failed_count}",
+        f"  Success rate: {success_rate:.2%}",
+        f"  Required threshold: {success_threshold:.2%}",
+        "",
+        "Failed samples:",
+    ]
+
+    for failure in failed_samples[:5]:  # Show first 5 failures
+        sample_idx = failure["sample_index"]
+        exception = failure["exception"]
+        check_results = failure["check_results"]
+
+        report_lines.append(f"  Sample {sample_idx}:")
+
+        if exception:
+            report_lines.append(f"    Exception: {type(exception).__name__}: {exception}")
+
+        for check_result in check_results:
+            if check_result.status != 'completed':
+                report_lines.append(f"    Check '{check_result.check_type}': {check_result.status}")  # noqa: E501
+                if check_result.error:
+                    report_lines.append(f"      Error: {check_result.error.message}")
+            elif not check_result.results.get('passed', False):
+                report_lines.append(f"    Check '{check_result.check_type}': failed")
+                # Add additional details if available
+                if 'reasoning' in check_result.results:
+                    report_lines.append(f"      Reasoning: {check_result.results['reasoning']}")
+
+    if len(failed_samples) > 5:
+        report_lines.append(f"  ... and {len(failed_samples) - 5} more failures")
+
+    pytest.fail("\n".join(report_lines))

--- a/src/flex_evals/pytest_decorator.py
+++ b/src/flex_evals/pytest_decorator.py
@@ -474,11 +474,17 @@ def _generate_failure_report(
                     report_lines.append(f"    Test case {i} check '{check_result.check_type}': {check_result.status}")  # noqa: E501
                     if check_result.error:
                         report_lines.append(f"      Error: {check_result.error.message}")
+                    # Add resolved arguments for debugging error cases too
+                    if check_result.resolved_arguments:
+                        report_lines.append(f"      Resolved arguments: {check_result.resolved_arguments}")  # noqa: E501
                 elif not check_result.results.get('passed', False):
                     report_lines.append(f"    Test case {i} check '{check_result.check_type}': failed")  # noqa: E501
                     # Add additional details if available
                     if 'reasoning' in check_result.results:
                         report_lines.append(f"      Reasoning: {check_result.results['reasoning']}")  # noqa: E501
+                    # Add resolved arguments for debugging
+                    if check_result.resolved_arguments:
+                        report_lines.append(f"      Resolved arguments: {check_result.resolved_arguments}")  # noqa: E501
 
     if len(failed_samples) > 5:
         report_lines.append(f"  ... and {len(failed_samples) - 5} more failures")

--- a/tests/test_pytest_decorator.py
+++ b/tests/test_pytest_decorator.py
@@ -1,0 +1,798 @@
+"""Tests for pytest decorator implementation using real checks (no mocks)."""
+
+import pytest
+import _pytest.outcomes
+from pydantic import BaseModel, Field
+
+from flex_evals.pytest_decorator import evaluate
+from flex_evals.schemas import TestCase, Check
+from flex_evals.constants import CheckType
+from typing import Never
+
+
+# Test response models for LLM judge tests
+class MockQualityResult(BaseModel):
+    """Mock quality assessment result."""
+
+    passed: bool = Field(description="Whether the check passed")
+    score: int = Field(ge=1, le=5, description="Quality score")
+    reasoning: str = Field(description="Reasoning for the assessment")
+
+
+class MockBooleanResult(BaseModel):
+    """Mock boolean result."""
+
+    passed: bool = Field(description="Whether the check passed")
+
+
+class TestEvaluateDecoratorBasicFunctionality:
+    """Test basic decorator functionality with real checks."""
+
+    def test_basic_success_scenario(self):
+        """Test basic successful evaluation with deterministic function."""
+
+        @evaluate(
+            test_cases=[TestCase(id="basic", input="test input")],
+            checks=[Check(
+                type=CheckType.CONTAINS,
+                arguments={"text": "$.output.value", "phrases": ["Python"]},
+            )],
+            samples=3,
+            success_threshold=1.0,
+        )
+        def deterministic_success() -> str:
+            return "Python is awesome"
+
+        # Should pass silently (pytest convention)
+        result = deterministic_success()
+        assert result is None
+
+    def test_basic_failure_scenario(self):
+        """Test basic failure scenario with deterministic function."""
+
+        @evaluate(
+            test_cases=[TestCase(id="fail", input="test input")],
+            checks=[Check(
+                type=CheckType.EXACT_MATCH,
+                arguments={"expected": "never_matches", "actual": "$.output.value"},
+            )],
+            samples=3,
+            success_threshold=0.5,
+        )
+        def deterministic_failure() -> str:
+            return "different_value"
+
+        # Should fail with pytest.fail
+        with pytest.raises(_pytest.outcomes.Failed) as exc_info:
+            deterministic_failure()
+
+        error_message = str(exc_info.value)
+        assert "Statistical evaluation failed" in error_message
+        assert "Success rate: 0.00%" in error_message
+        assert "Required threshold: 50.00%" in error_message
+
+    def test_exact_threshold_success(self):
+        """Test success when success rate exactly meets threshold."""
+        call_count = 0
+
+        @evaluate(
+            test_cases=[TestCase(id="exact", input="test")],
+            checks=[Check(
+                type=CheckType.EXACT_MATCH,
+                arguments={"expected": "pass", "actual": "$.output.value"},
+            )],
+            samples=4,
+            success_threshold=0.75,  # Exactly 75%
+        )
+        def exact_threshold_function() -> str:
+            nonlocal call_count
+            call_count += 1
+            # Pass exactly 3 out of 4 times (75%)
+            return "pass" if call_count <= 3 else "fail"
+
+        # Should pass since 75% meets 75% threshold
+        exact_threshold_function()
+
+
+class TestEvaluateDecoratorStatistical:
+    """Test statistical evaluation scenarios."""
+
+    def test_statistical_evaluation_success(self):
+        """Test statistical threshold evaluation with passing rate."""
+        call_count = 0
+
+        @evaluate(
+            test_cases=[TestCase(id="stats", input="test")],
+            checks=[Check(
+                type=CheckType.EXACT_MATCH,
+                arguments={"expected": "pass", "actual": "$.output.value"},
+            )],
+            samples=10,
+            success_threshold=0.7,  # 70% threshold
+        )
+        def statistical_function() -> str:
+            nonlocal call_count
+            call_count += 1
+            # 80% success rate (8 out of 10)
+            return "pass" if call_count % 10 != 1 and call_count % 10 != 2 else "fail"
+
+        # Should pass (80% > 70%)
+        statistical_function()
+
+    def test_statistical_evaluation_failure(self):
+        """Test statistical threshold evaluation with failing rate."""
+        call_count = 0
+
+        @evaluate(
+            test_cases=[TestCase(id="stats_fail", input="test")],
+            checks=[Check(
+                type=CheckType.EXACT_MATCH,
+                arguments={"expected": "pass", "actual": "$.output.value"},
+            )],
+            samples=10,
+            success_threshold=0.8,  # 80% threshold
+        )
+        def statistical_failure_function() -> str:
+            nonlocal call_count
+            call_count += 1
+            # 60% success rate (6 out of 10)
+            return "pass" if call_count % 10 < 6 else "fail"
+
+        # Should fail (60% < 80%)
+        with pytest.raises(_pytest.outcomes.Failed) as exc_info:
+            statistical_failure_function()
+
+        error_message = str(exc_info.value)
+        assert "Success rate: 60.00%" in error_message
+        assert "Required threshold: 80.00%" in error_message
+
+    def test_high_variance_statistical_evaluation(self):
+        """Test with high variance in results."""
+        call_count = 0
+
+        @evaluate(
+            test_cases=[TestCase(id="variance", input="test")],
+            checks=[Check(
+                type=CheckType.CONTAINS,
+                arguments={"text": "$.output.value", "phrases": ["success"]},
+            )],
+            samples=20,
+            success_threshold=0.65,  # 65% threshold
+        )
+        def high_variance_function() -> str:
+            nonlocal call_count
+            call_count += 1
+            # ~70% success rate with some variance
+            return "success result" if call_count % 10 < 7 else "failure result"
+
+        # Should pass most of the time (70% > 65%)
+        high_variance_function()
+
+
+class TestEvaluateDecoratorErrorHandling:
+    """Test error handling scenarios."""
+
+    def test_function_exceptions_as_failures(self):
+        """Test that function exceptions are counted as failures."""
+        call_count = 0
+
+        @evaluate(
+            test_cases=[TestCase(id="exceptions", input="test")],
+            checks=[Check(
+                type=CheckType.EXACT_MATCH,
+                arguments={"expected": "success", "actual": "$.output.value"},
+            )],
+            samples=6,
+            success_threshold=0.4,  # 40% threshold
+        )
+        def exception_prone_function() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 3:
+                return "success"  # First 3 succeed
+            raise RuntimeError(f"Error on call {call_count}")
+
+        # 3/6 = 50% success rate > 40% threshold, should pass
+        exception_prone_function()
+
+    def test_all_exceptions_failure(self):
+        """Test scenario where all function calls raise exceptions."""
+
+        @evaluate(
+            test_cases=[TestCase(id="all_exceptions", input="test")],
+            checks=[Check(
+                type=CheckType.EXACT_MATCH,
+                arguments={"expected": "success", "actual": "$.output.value"},
+            )],
+            samples=3,
+            success_threshold=0.1,  # Even 10% threshold
+        )
+        def always_throws() -> Never:
+            raise ValueError("Always fails")
+
+        # Should fail with 0% success rate
+        with pytest.raises(_pytest.outcomes.Failed) as exc_info:
+            always_throws()
+
+        error_message = str(exc_info.value)
+        assert "Success rate: 0.00%" in error_message
+        assert "Exception: ValueError: Always fails" in error_message
+
+    def test_mixed_exceptions_and_failures(self):
+        """Test mix of exceptions and check failures."""
+        call_count = 0
+
+        @evaluate(
+            test_cases=[TestCase(id="mixed", input="test")],
+            checks=[Check(
+                type=CheckType.EXACT_MATCH,
+                arguments={"expected": "success", "actual": "$.output.value"},
+            )],
+            samples=9,
+            success_threshold=0.25,  # 25% threshold
+        )
+        def mixed_failure_function() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 3:
+                return "success"  # First 3 succeed
+            if call_count <= 6:
+                return "fail"  # Next 3 fail checks
+            raise RuntimeError(f"Exception on call {call_count}")  # Last 3 throw
+
+        # 3/9 = 33.33% success rate > 25% threshold, should pass
+        mixed_failure_function()
+
+
+class TestEvaluateDecoratorCheckTypes:
+    """Test with different check types."""
+
+    def test_multiple_checks_all_pass(self):
+        """Test with multiple different check types that all pass."""
+
+        @evaluate(
+            test_cases=[TestCase(
+                id="multi",
+                input="test input",
+                expected="expected_output",
+            )],
+            checks=[
+                Check(
+                    type=CheckType.CONTAINS,
+                    arguments={"text": "$.output.value.message", "phrases": ["key"]},
+                ),
+                Check(
+                    type=CheckType.EXACT_MATCH,
+                    arguments={"expected": "$.test_case.expected", "actual": "$.output.value.result"},  # noqa: E501
+                ),
+            ],
+            samples=2,
+            success_threshold=1.0,
+        )
+        def multi_check_function():  # noqa: ANN202
+            return {
+                "result": "expected_output",  # Matches exact check
+                "message": "This contains the key phrase",  # Matches contains check
+            }
+
+        multi_check_function()
+
+    def test_multiple_checks_partial_pass(self):
+        """Test with multiple checks where some pass and some fail."""
+
+        @evaluate(
+            test_cases=[TestCase(
+                id="partial",
+                input="test",
+                expected="exact_match",
+            )],
+            checks=[
+                Check(
+                    type=CheckType.CONTAINS,
+                    arguments={"text": "$.output.value", "phrases": ["success"]},
+                ),
+                Check(
+                    type=CheckType.EXACT_MATCH,
+                    arguments={"expected": "$.test_case.expected", "actual": "$.output.value"},
+                ),
+            ],
+            samples=4,
+            success_threshold=0.25,  # 25% threshold
+        )
+        def partial_check_function() -> str:
+            # Only passes contains check, fails exact match
+            return "success message but not exact match"
+
+        # Should fail since BOTH checks must pass for a sample to pass
+        with pytest.raises(_pytest.outcomes.Failed):
+            partial_check_function()
+
+    def test_regex_check_integration(self):
+        """Test with regex check."""
+
+        @evaluate(
+            test_cases=[TestCase(id="regex_test", input="test")],
+            checks=[Check(
+                type=CheckType.REGEX,
+                arguments={
+                    "pattern": r"Result: \d+",
+                    "text": "$.output.value",
+                },
+            )],
+            samples=3,
+            success_threshold=1.0,
+        )
+        def regex_function() -> str:
+            return "Result: 42"
+
+        regex_function()
+
+    def test_threshold_check_integration(self):
+        """Test with threshold check."""
+
+        @evaluate(
+            test_cases=[TestCase(id="threshold_test", input="test")],
+            checks=[Check(
+                type=CheckType.THRESHOLD,
+                arguments={
+                    "value": "$.output.value.score",
+                    "min_value": 80,
+                    "max_value": 100,
+                },
+            )],
+            samples=2,
+            success_threshold=1.0,
+        )
+        def threshold_function():  # noqa: ANN202
+            return {"score": 95, "message": "High quality"}
+
+        threshold_function()
+
+
+class TestEvaluateDecoratorLLMJudge:
+    """Test LLM judge integration."""
+
+    def test_llm_judge_with_mock_function(self):
+        """Test LLM judge with deterministic mock function."""
+
+        def deterministic_llm_function(prompt: str, response_format: type) -> tuple:
+            """Deterministic mock LLM for testing."""
+            if "good response" in prompt:
+                return response_format(
+                    passed=True,
+                    score=5,
+                    reasoning="Excellent response",
+                ), {"cost_usd": 0.01}
+            return response_format(
+                passed=False,
+                score=2,
+                reasoning="Poor response",
+            ), {"cost_usd": 0.01}
+
+        @evaluate(
+            test_cases=[TestCase(id="llm_test", input="test query")],
+            checks=[Check(
+                type=CheckType.LLM_JUDGE,
+                arguments={
+                    "prompt": "Evaluate this response: {{$.output.value}}",
+                    "response_format": MockQualityResult,
+                    "llm_function": deterministic_llm_function,
+                },
+            )],
+            samples=3,
+            success_threshold=1.0,
+        )
+        def good_response_function() -> str:
+            return "This is a good response"
+
+        good_response_function()
+
+    def test_llm_judge_statistical_evaluation(self):
+        """Test LLM judge with variable quality responses."""
+
+        def variable_llm_function(prompt: str, response_format: type) -> tuple:
+            """Mock LLM that varies assessment based on content."""
+            if "excellent" in prompt:
+                return response_format(passed=True, score=5, reasoning="Great"), {}
+            if "good" in prompt:
+                return response_format(passed=True, score=4, reasoning="Good"), {}
+            if "okay" in prompt:
+                return response_format(passed=True, score=3, reasoning="Okay"), {}
+            return response_format(passed=False, score=2, reasoning="Poor"), {}
+
+        call_count = 0
+
+        @evaluate(
+            test_cases=[TestCase(id="variable_llm", input="test")],
+            checks=[Check(
+                type=CheckType.LLM_JUDGE,
+                arguments={
+                    "prompt": "Rate this: {{$.output.value}}",
+                    "response_format": MockQualityResult,
+                    "llm_function": variable_llm_function,
+                },
+            )],
+            samples=8,
+            success_threshold=0.6,  # 60% threshold
+        )
+        def variable_quality_function() -> str:
+            nonlocal call_count
+            call_count += 1
+            responses = ["excellent", "good", "okay", "poor"] * 2
+            return f"This is {responses[call_count - 1]} content"
+
+        # Should pass: excellent(pass) + good(pass) + okay(pass) + poor(fail) = 6/8 = 75% > 60%
+        variable_quality_function()
+
+    def test_llm_judge_with_flattened_response(self):
+        """Test that LLM judge returns flattened response structure."""
+
+        def simple_llm_function(prompt: str, response_format: type) -> tuple:  # noqa: ARG001
+            return response_format(passed=True), {"cost": 0.01}
+
+        @evaluate(
+            test_cases=[TestCase(id="flattened", input="test")],
+            checks=[Check(
+                type=CheckType.LLM_JUDGE,
+                arguments={
+                    "prompt": "Simple evaluation: {{$.output.value}}",
+                    "response_format": MockBooleanResult,
+                    "llm_function": simple_llm_function,
+                },
+            )],
+            samples=2,
+            success_threshold=1.0,
+        )
+        def simple_function() -> str:
+            return "test response"
+
+        # This test verifies the LLM judge integration works with flattened response
+        simple_function()
+
+
+class TestEvaluateDecoratorTestCaseChecks:
+    """Test TestCase-defined checks functionality."""
+
+    def test_test_case_defined_checks(self):
+        """Test with checks defined in TestCase objects."""
+        test_case_with_checks = TestCase(
+            id="with_checks",
+            input="test input",
+            checks=[Check(
+                type=CheckType.CONTAINS,
+                arguments={"text": "$.output.value", "phrases": ["success"]},
+            )],
+        )
+
+        @evaluate(
+            test_cases=[test_case_with_checks],
+            checks=None,  # Use TestCase checks
+            samples=3,
+            success_threshold=1.0,
+        )
+        def test_case_checks_function() -> str:
+            return "This is a success message"
+
+        test_case_checks_function()
+
+    def test_multiple_test_cases_with_different_checks(self):
+        """Test multiple test cases with different checks."""
+        test_cases = [
+            TestCase(
+                id="contains_check",
+                input="input1",
+                checks=[Check(
+                    type=CheckType.CONTAINS,
+                    arguments={"text": "$.output.value", "phrases": ["alpha"]},
+                )],
+            ),
+            TestCase(
+                id="exact_check",
+                input="input2",
+                checks=[Check(
+                    type=CheckType.EXACT_MATCH,
+                    arguments={"expected": "beta", "actual": "$.output.value"},
+                )],
+            ),
+        ]
+
+        call_count = 0
+
+        @evaluate(
+            test_cases=test_cases,
+            checks=None,
+            samples=4,  # Will cycle: contains, exact, contains, exact
+            success_threshold=1.0,
+        )
+        def cycling_function() -> str:
+            nonlocal call_count
+            call_count += 1
+            # Return appropriate response based on which test case we're cycling to
+            if call_count % 2 == 1:
+                return "response with alpha"  # For contains check
+            return "beta"  # For exact match check
+
+        cycling_function()
+
+    def test_cycling_through_test_cases(self):
+        """Test cycling through multiple test cases preserves original structure."""
+        test_cases = [
+            TestCase(id="case1", input="input1", expected="result1"),
+            TestCase(id="case2", input="input2", expected="result2"),
+        ]
+
+        call_count = 0
+
+        @evaluate(
+            test_cases=test_cases,
+            checks=[Check(
+                type=CheckType.EXACT_MATCH,
+                arguments={"expected": "$.test_case.expected", "actual": "$.output.value"},
+            )],
+            samples=4,  # Will cycle: case1, case2, case1, case2
+            success_threshold=1.0,
+        )
+        def cycling_function() -> str:
+            nonlocal call_count
+            call_count += 1
+            # Return expected value based on which test case we're on
+            if call_count % 2 == 1:
+                return "result1"  # For case1
+            return "result2"  # For case2
+
+        cycling_function()
+
+
+class TestEvaluateDecoratorEdgeCases:
+    """Test edge cases and complex scenarios."""
+
+    def test_complex_return_value_structures(self):
+        """Test with complex return value types."""
+
+        @evaluate(
+            test_cases=[TestCase(id="complex", input="test")],
+            checks=[Check(
+                type=CheckType.CONTAINS,
+                arguments={"text": "$.output.value.message", "phrases": ["success"]},
+            )],
+            samples=2,
+            success_threshold=1.0,
+        )
+        def complex_return_function():  # noqa: ANN202
+            return {
+                "message": "Operation was a success",
+                "data": {"items": [1, 2, 3]},
+                "metadata": {"timestamp": "2024-01-01"},
+            }
+
+        complex_return_function()
+
+    def test_none_return_value(self):
+        """Test function that returns None (wrapped in dict)."""
+
+        @evaluate(
+            test_cases=[TestCase(id="none_test", input="test")],
+            checks=[Check(
+                type=CheckType.EXACT_MATCH,
+                arguments={"expected": None, "actual": "$.output.value.result"},
+            )],
+            samples=2,
+            success_threshold=1.0,
+        )
+        def none_return_function():  # noqa: ANN202
+            # Output.value can't be None, so wrap it in a dict
+            return {"result": None}
+
+        none_return_function()
+
+    def test_string_return_value(self):
+        """Test function that returns simple string."""
+
+        @evaluate(
+            test_cases=[TestCase(id="string_test", input="test")],
+            checks=[Check(
+                type=CheckType.EXACT_MATCH,
+                arguments={"expected": "simple string", "actual": "$.output.value"},
+            )],
+            samples=2,
+            success_threshold=1.0,
+        )
+        def string_return_function() -> str:
+            return "simple string"
+
+        string_return_function()
+
+    def test_list_return_value(self):
+        """Test function that returns list (wrapped in dict)."""
+
+        @evaluate(
+            test_cases=[TestCase(id="list_test", input="test")],
+            checks=[Check(
+                type=CheckType.EXACT_MATCH,
+                arguments={"expected": [1, 2, 3], "actual": "$.output.value.items"},
+            )],
+            samples=2,
+            success_threshold=1.0,
+        )
+        def list_return_function():  # noqa: ANN202
+            # Output.value can't be a list, so wrap it in a dict
+            return {"items": [1, 2, 3]}
+
+        list_return_function()
+
+    def test_single_sample_evaluation(self):
+        """Test evaluation with only one sample."""
+
+        @evaluate(
+            test_cases=[TestCase(id="single", input="test")],
+            checks=[Check(
+                type=CheckType.EXACT_MATCH,
+                arguments={"expected": "success", "actual": "$.output.value"},
+            )],
+            samples=1,
+            success_threshold=1.0,
+        )
+        def single_sample_function() -> str:
+            return "success"
+
+        single_sample_function()
+
+    def test_large_sample_count(self):
+        """Test with larger sample count for performance validation."""
+
+        @evaluate(
+            test_cases=[TestCase(id="large", input="test")],
+            checks=[Check(
+                type=CheckType.CONTAINS,
+                arguments={"text": "$.output.value", "phrases": ["pass"]},
+            )],
+            samples=50,
+            success_threshold=0.9,
+        )
+        def large_sample_function() -> str:
+            return "This should pass every time"
+
+        large_sample_function()
+
+
+class TestEvaluateDecoratorParameterValidation:
+    """Test parameter validation."""
+
+    def test_empty_test_cases_error(self):
+        """Test error when test_cases is empty."""
+        with pytest.raises(ValueError, match="test_cases list cannot be empty"):
+            @evaluate(
+                test_cases=[],
+                checks=[Check(type=CheckType.EXACT_MATCH, arguments={})],
+                samples=1,
+                success_threshold=1.0,
+            )
+            def empty_test_cases() -> str:
+                return "test"
+
+    def test_zero_samples_error(self):
+        """Test error when samples is zero."""
+        with pytest.raises(ValueError, match="samples must be positive"):
+            @evaluate(
+                test_cases=[TestCase(id="test", input="test")],
+                checks=[Check(type=CheckType.EXACT_MATCH, arguments={})],
+                samples=0,
+                success_threshold=1.0,
+            )
+            def zero_samples() -> str:
+                return "test"
+
+    def test_negative_samples_error(self):
+        """Test error when samples is negative."""
+        with pytest.raises(ValueError, match="samples must be positive"):
+            @evaluate(
+                test_cases=[TestCase(id="test", input="test")],
+                checks=[Check(type=CheckType.EXACT_MATCH, arguments={})],
+                samples=-1,
+                success_threshold=1.0,
+            )
+            def negative_samples() -> str:
+                return "test"
+
+    def test_invalid_threshold_high_error(self):
+        """Test error when success_threshold is > 1.0."""
+        with pytest.raises(ValueError, match="success_threshold must be between 0.0 and 1.0"):
+            @evaluate(
+                test_cases=[TestCase(id="test", input="test")],
+                checks=[Check(type=CheckType.EXACT_MATCH, arguments={})],
+                samples=1,
+                success_threshold=1.5,
+            )
+            def invalid_high_threshold() -> str:
+                return "test"
+
+    def test_invalid_threshold_low_error(self):
+        """Test error when success_threshold is < 0.0."""
+        with pytest.raises(ValueError, match="success_threshold must be between 0.0 and 1.0"):
+            @evaluate(
+                test_cases=[TestCase(id="test", input="test")],
+                checks=[Check(type=CheckType.EXACT_MATCH, arguments={})],
+                samples=1,
+                success_threshold=-0.1,
+            )
+            def invalid_low_threshold() -> str:
+                return "test"
+
+    def test_no_checks_anywhere_error(self):
+        """Test error when no checks are defined anywhere."""
+        test_case_no_checks = TestCase(id="no_checks", input="test input")
+
+        with pytest.raises(ValueError, match="each TestCase must define its own checks"):
+            @evaluate(
+                test_cases=[test_case_no_checks],
+                checks=None,
+                samples=1,
+                success_threshold=1.0,
+            )
+            def no_checks_function() -> str:
+                return "test"
+
+
+class TestEvaluateDecoratorFailureReporting:
+    """Test failure reporting functionality."""
+
+    def test_detailed_failure_report(self):
+        """Test that failure reports contain detailed information."""
+
+        @evaluate(
+            test_cases=[TestCase(id="detailed_fail", input="test")],
+            checks=[
+                Check(
+                    type=CheckType.EXACT_MATCH,
+                    arguments={"expected": "never", "actual": "$.output.value"},
+                ),
+                Check(
+                    type=CheckType.CONTAINS,
+                    arguments={"text": "$.output.value", "phrases": ["missing"]},
+                ),
+            ],
+            samples=2,
+            success_threshold=0.5,
+        )
+        def detailed_failure_function() -> str:
+            return "always fails both checks"
+
+        with pytest.raises(_pytest.outcomes.Failed) as exc_info:
+            detailed_failure_function()
+
+        error_message = str(exc_info.value)
+
+        # Check that detailed information is present
+        assert "Statistical evaluation failed" in error_message
+        assert "Total samples: 2" in error_message
+        assert "Passed: 0" in error_message
+        assert "Failed: 2" in error_message
+        assert "Failed samples:" in error_message
+        assert "Sample 0:" in error_message
+        assert "Sample 1:" in error_message
+
+    def test_failure_report_with_exceptions(self):
+        """Test failure report includes exception details."""
+        call_count = 0
+
+        @evaluate(
+            test_cases=[TestCase(id="exception_report", input="test")],
+            checks=[Check(
+                type=CheckType.EXACT_MATCH,
+                arguments={"expected": "success", "actual": "$.output.value"},
+            )],
+            samples=3,
+            success_threshold=0.8,  # 80% threshold
+        )
+        def exception_reporting_function() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return "success"  # First call succeeds
+            raise ValueError(f"Test exception {call_count}")
+
+        with pytest.raises(_pytest.outcomes.Failed) as exc_info:
+            exception_reporting_function()
+
+        error_message = str(exc_info.value)
+        assert "Exception: ValueError: Test exception" in error_message


### PR DESCRIPTION
## Summary

This PR introduces a new `@evaluate` pytest decorator that enables statistical evaluation of test functions using the flex-evals framework. The decorator allows developers to run functions multiple times, apply validation checks, and assert success thresholds directly within pytest test suites.

## Changes

- **New pytest decorator**: Added `@evaluate` decorator in `src/flex_evals/pytest_decorator.py` for statistical function evaluation
- **LLM judge response structure update**: Modified LLM judge check to flatten response structure and separate judge metadata for better integration
- **Comprehensive examples**: Added `examples/pytest_decorator_example.py` with deterministic examples covering all major use cases
- **Documentation**: Updated README.md with pytest integration section and usage examples
- **Test coverage**: Added extensive test suite in `tests/test_pytest_decorator.py` (1,354 lines) covering sync/async functions, fixtures, error handling, and statistical evaluation
- **Build integration**: Updated Makefile to include decorator examples in the test suite

## Testing

- **Example validation**: Deterministic examples in `pytest_decorator_example.py` that run in CI
- **Backwards compatibility**: Existing LLM judge tests updated to handle new flattened response structure
- **Performance testing**: Async concurrency validation and large-scale evaluation tests

## Impact

**Breaking changes**: 
- LLM judge check response structure changed from nested `{"response": {...}, "metadata": {...}}` to flattened structure with separate `judge_metadata` field

**New dependencies**: None

**Deployment considerations**: Existing code using LLM judge checks will need to update result access patterns (e.g., `result["response"]["score"]` becomes `result["score"]`)

The decorator provides a new way to integrate statistical evaluation into standard pytest workflows, enabling developers to validate LLM and system reliability directly in their test suites.